### PR TITLE
Improve the 400 response on /profile and /allocs_profile: describe required params

### DIFF
--- a/src/PerformanceProfilingHttpEndpoints.jl
+++ b/src/PerformanceProfilingHttpEndpoints.jl
@@ -27,12 +27,23 @@ default_duration() = "10.0"
 default_pprof() = "true"
 default_alloc_sample_rate() = "0.0001"
 
+cpu_profile_error_message() = """Need to provide query params:
+    - duration=$(default_duration())
+    - delay=$(default_delay())
+    - n=$(default_n())
+    - pprof=$(default_pprof())
+"""
+allocs_profile_error_message() = """Need to provide query params:
+    - duration=$(default_duration())
+    - sample_rate=$(default_alloc_sample_rate())
+"""
+
 function cpu_profile_endpoint(req::HTTP.Request)
     uri = HTTP.URI(HTTP.Messages.uri(req))
     qp = HTTP.queryparams(uri)
     if isempty(qp)
         @info "TODO: interactive HTML input page"
-        return HTTP.Response(400, "Need to provide query params: e.g. duration=")
+        return HTTP.Response(400, cpu_profile_error_message())
     end
 
     # Run the profile
@@ -88,7 +99,7 @@ function allocations_profile_endpoint(req::HTTP.Request)
     qp = HTTP.queryparams(uri)
     if isempty(qp)
         @info "TODO: interactive HTML input page"
-        return HTTP.Response(400, "Need to provide query params: e.g. duration=")
+        return HTTP.Response(400, allocs_profile_error_message())
     end
 
     sample_rate = convert(Float64, parse(Float64, get(qp, "sample_rate", default_alloc_sample_rate())))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,25 +70,27 @@ const url = "http://127.0.0.1:$port"
         done[] = true
         wait(t)  # handle errors
     end
-end
 
-@testset "error handling" begin
-    let res = HTTP.request("GET", "$url/profile", status_exception=false)
-        @test 400 <= res.status < 500
-        @test res.status != 404
-        # Make sure we describe how to use the endpoint
-        body = String(res.body)
-        @test occursin("duration", body)
-        @test occursin("delay", body)
-    end
+    @testset "error handling" begin
+        let res = HTTP.request("GET", "$url/profile", status_exception=false)
+            @test 400 <= res.status < 500
+            @test res.status != 404
+            # Make sure we describe how to use the endpoint
+            body = String(res.body)
+            @test occursin("duration", body)
+            @test occursin("delay", body)
+        end
 
-    let res = HTTP.request("GET", "$url/allocs_profile", status_exception=false)
-        @test 400 <= res.status < 500
-        @test res.status != 404
-        # Make sure we describe how to use the endpoint
-        body = String(res.body)
-        @test occursin("duration", body)
-        @test occursin("sample_rate", body)
+        if (isdefined(Profile, :Allocs) && isdefined(PProf, :Allocs))
+            let res = HTTP.request("GET", "$url/allocs_profile", status_exception=false)
+                @test 400 <= res.status < 500
+                @test res.status != 404
+                # Make sure we describe how to use the endpoint
+                body = String(res.body)
+                @test occursin("duration", body)
+                @test occursin("sample_rate", body)
+            end
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,4 +72,24 @@ const url = "http://127.0.0.1:$port"
     end
 end
 
+@testset "error handling" begin
+    let res = HTTP.request("GET", "$url/profile", status_exception=false)
+        @test 400 <= res.status < 500
+        @test res.status != 404
+        # Make sure we describe how to use the endpoint
+        body = String(res.body)
+        @test occursin("duration", body)
+        @test occursin("delay", body)
+    end
+
+    let res = HTTP.request("GET", "$url/allocs_profile", status_exception=false)
+        @test 400 <= res.status < 500
+        @test res.status != 404
+        # Make sure we describe how to use the endpoint
+        body = String(res.body)
+        @test occursin("duration", body)
+        @test occursin("sample_rate", body)
+    end
+end
+
 end # module PerformanceProfilingHttpEndpointsTests


### PR DESCRIPTION
Improve the 400 response on /profile and /allocs_profile: describe required params

This way the user knows what query params they're supposed to enter into
the URL.

Before:
```
Need to provide query params: e.g. duration=
```

After:
```
Need to provide query params:
    - duration=10.0
    - delay=0.01
    - n=1e8
    - pprof=true
```
and:
```
Need to provide query params:
    - duration=10.0
    - sample_rate=0.0001
```