### PR TITLE
Add heap snapshot endpoint

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.6"
-          - "1"
+          - "1.6"  # LTS
+          - "1"    # Latest
+          - "1.9"  # To test heap snapshot; remove when v1.9 is latest Julia release.
           - "nightly"
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
         version:
           - "1.6"  # LTS
           - "1"    # Latest
-          - "1.9"  # To test heap snapshot; remove when v1.9 is latest Julia release.
+          - "~1.9.0-0"  # To test heap snapshot; remove when v1.9 is latest Julia release.
           - "nightly"
         os:
           - ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Currently provides:
     - `/profile?n=1e8&delay=0.01&duration=10&pprof=true`
 - `/allocs_profile` endpoint, with default query params:
     - `/allocs_profile?sample_rate=0.0001&duration=10`
+- `/heap_snapshot` endpoint, with default query params:
+    - `/heap_snapshot?all_one=false`
 
 
 ## Example


### PR DESCRIPTION
Adds `/heap_snapshot` taking query param `all_one` (default `all_one=false`), which returns a `.heapsnapshot` file using the `Profile.take_heap_snaphot` functionality available in v1.9+ (https://github.com/JuliaLang/julia/pull/46862, see also https://github.com/JuliaLang/julia/pull/42286).

Adds minimal docs for now, will re-vamp the README with the recently added functionality in a follow-up PR.