### PR TITLE
Rename package `PerformanceProfilingHttpEndpoints` -> `ProfileEndpoints`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /Manifest.toml
 .vscode
 test/Manifest.toml
+*.pb.gz
+*.pprof
+*.heapsnapshot

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProfileEndpoints"
 uuid = "873a18e9-432f-47dd-82a7-1a805cf6f852"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Dana Wilson <odioustoad@gmail.com>"]
-version = "0.2.10"
+version = "1.0.0"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "PerformanceProfilingHttpEndpoints"
+name = "ProfileEndpoints"
 uuid = "773a18e9-432f-47dd-82a7-1a805cf6f851"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Dana Wilson <odioustoad@gmail.com>"]
 version = "0.2.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "ProfileEndpoints"
-uuid = "773a18e9-432f-47dd-82a7-1a805cf6f851"
+uuid = "873a18e9-432f-47dd-82a7-1a805cf6f852"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Dana Wilson <odioustoad@gmail.com>"]
 version = "0.2.10"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PerformanceProfilingHttpEndpoints
+# ProfileEndpoints
 
 Provides HTTP endpoints (and an optional HTTP server) that wrap the profiling
 functionality exposed from existing Julia packages, to allow introspecting a live-running
@@ -36,7 +36,7 @@ Start the server on your production process
 julia> Threads.nthreads()
 4
 
-julia> t = @async PerformanceProfilingHttpEndpoints.serve_profiling_server()  # Start the profiling server in the background
+julia> t = @async ProfileEndpoints.serve_profiling_server()  # Start the profiling server in the background
 [ Info: Starting HTTP profiling server on port 16825
 Task (runnable) @0x0000000113c8d660
 

--- a/src/ProfileEndpoints.jl
+++ b/src/ProfileEndpoints.jl
@@ -1,4 +1,4 @@
-module PerformanceProfilingHttpEndpoints
+module ProfileEndpoints
 
 import HTTP
 import Profile
@@ -89,7 +89,7 @@ end
 
 function cpu_profile_stop_endpoint(req::HTTP.Request)
     Profile.stop_timer()
-    @info "Stopping CPU Profiling from PerformanceProfilingHttpEndpoints"
+    @info "Stopping CPU Profiling from ProfileEndpoints"
     uri = HTTP.URI(req.target)
     qp = HTTP.queryparams(uri)
     with_pprof = parse(Bool, get(qp, "pprof", default_pprof()))
@@ -98,7 +98,7 @@ function cpu_profile_stop_endpoint(req::HTTP.Request)
 end
 
 function _do_cpu_profile(n, delay, duration, with_pprof)
-    @info "Starting CPU Profiling from PerformanceProfilingHttpEndpoints with configuration:" n delay duration
+    @info "Starting CPU Profiling from ProfileEndpoints with configuration:" n delay duration
     Profile.clear()
     Profile.init(n, delay)
     Profile.@profile sleep(duration)
@@ -107,7 +107,7 @@ function _do_cpu_profile(n, delay, duration, with_pprof)
 end
 
 function _start_cpu_profile(n, delay)
-    @info "Starting CPU Profiling from PerformanceProfilingHttpEndpoints with configuration:" n delay
+    @info "Starting CPU Profiling from ProfileEndpoints with configuration:" n delay
     resp = HTTP.Response(200, "CPU profiling started.")
     Profile.clear()
     Profile.init(n, delay)
@@ -150,7 +150,7 @@ function heap_snapshot_endpoint(req::HTTP.Request)
     qp = HTTP.queryparams(uri)
     all_one = parse(Bool, get(qp, "all_one", default_heap_all_one()))
     filename = Profile.take_heap_snapshot(all_one)
-    @info "Taking heap snapshot from PerformanceProfilingHttpEndpoints" all_one filename
+    @info "Taking heap snapshot from ProfileEndpoints" all_one filename
     return _http_response(read(filename), filename)
 end
 
@@ -211,7 +211,7 @@ function allocations_stop_endpoint(req::HTTP.Request)
 end
 
 function _do_alloc_profile(duration, sample_rate)
-    @info "Starting allocation Profiling from PerformanceProfilingHttpEndpoints with configuration:" duration sample_rate
+    @info "Starting allocation Profiling from ProfileEndpoints with configuration:" duration sample_rate
 
     Profile.Allocs.clear()
 
@@ -225,7 +225,7 @@ function _do_alloc_profile(duration, sample_rate)
 end
 
 function _start_alloc_profile(sample_rate)
-    @info "Starting allocation Profiling from PerformanceProfilingHttpEndpoints with configuration:" sample_rate
+    @info "Starting allocation Profiling from ProfileEndpoints with configuration:" sample_rate
     resp = HTTP.Response(200, "Allocation profiling started.")
     Profile.Allocs.clear()
     Profile.Allocs.start(; sample_rate)
@@ -283,4 +283,4 @@ function __init__()
     end
 end
 
-end # module PerformanceProfilingHttpEndpoints
+end # module ProfileEndpoints

--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,0 @@
-# PerformanceProfilingHttpEndpoints.jl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
-module PerformanceProfilingHttpEndpointsTests
+module ProfileEndpointsTests
 
-using PerformanceProfilingHttpEndpoints
+using ProfileEndpoints
 using Test
 using Serialization
 
@@ -10,10 +10,10 @@ import Profile
 import PProf
 
 const port = 13423
-const server = PerformanceProfilingHttpEndpoints.serve_profiling_server(;port=port)
+const server = ProfileEndpoints.serve_profiling_server(;port=port)
 const url = "http://127.0.0.1:$port"
 
-@testset "PerformanceProfilingHttpEndpoints.jl" begin
+@testset "ProfileEndpoints.jl" begin
 
     @testset "CPU profiling" begin
         done = Threads.Atomic{Bool}(false)
@@ -179,4 +179,4 @@ end
 
 close(server)
 
-end # module PerformanceProfilingHttpEndpointsTests
+end # module ProfileEndpointsTests


### PR DESCRIPTION
- part of #14 
- need to rename the repo on Github + then register this newly renamed package