### PR TITLE
Inference profiling: Attempt to move the flamegraph conversion client-side

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,10 @@ authors = ["Nathan Daly <nhdaly@gmail.com>", "Dana Wilson <odioustoad@gmail.com>
 version = "1.0.0"
 
 [deps]
-FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 PProf = "e4faabce-9ead-11e9-39d9-4379958e3056"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-SnoopCompile = "aa65fe97-06da-5843-b5b1-d5d13cad87d2"
 SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 
 [compat]


### PR DESCRIPTION
But it doesn't work because the profile directly refers to the methods that were inferred server side, which the client-side doesn't know about.