### PR TITLE
Add compat to Project.toml for inference profiling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,9 @@ SnoopCompileCore = "e2b509da-e806-4183-be48-004708413034"
 [compat]
 HTTP = "1"
 PProf = "2"
+FlameGraphs = "1"
+SnoopCompile = "2.10"
+SnoopCompileCore = "2.10"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
This is because we added these deps in https://github.com/JuliaPerf/ProfileEndpoints.jl/pull/16.