### PR TITLE
update version to 2.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProfileEndpoints"
 uuid = "873a18e9-432f-47dd-82a7-1a805cf6f852"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Dana Wilson <odioustoad@gmail.com>"]
-version = "1.2.0"
+version = "2.0.0"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"


### PR DESCRIPTION
Update ProfileEndpoints version.

Note that https://github.com/JuliaPerf/ProfileEndpoints.jl/pull/35 introduced a breaking change in the sense we're no longer passing the profiling parameters for the `/debug_engine` endpoint in the query parameters, but are now passing them in the JSON body.

Because of this I'm making this PR a major version bump.