### PR TITLE
add ability to specify subdirectory in query parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProfileEndpoints"
 uuid = "873a18e9-432f-47dd-82a7-1a805cf6f852"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Dana Wilson <odioustoad@gmail.com>"]
-version = "2.4.0"
+version = "2.5.0"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"


### PR DESCRIPTION
Should be useful to get further control about where the profiles will be written.

This functionality assumes that someone else (i.e. ERP in RAI's case) has created the subdirectory and ProfileEndpoints will simply use it.