### PR TITLE
stream and then tar heap snapshot

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,6 +143,10 @@ const url = "http://127.0.0.1:$port"
                 req = HTTP.post("$url/debug_engine", headers, payload)
                 @test req.status == 200
                 fname = read(IOBuffer(req.body), String)
+                @static if isdefined(Profile, :HeapSnapshot) && isdefined(Profile.HeapSnapshot, :assemble_snapshot) && Sys.isunix()
+                    # test whether the returned file has a tar extension
+                    @test occursin(".tar", fname)
+                end
                 @info "filename: $fname"
                 @test isfile(fname)
             end


### PR DESCRIPTION
To avoid building the heap snapshot in-memory and therefore possibly OOMing if the process is under memory pressure.