### PR TITLE
rename /profile* to /cpu_profile*

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Julia process to interrogate its performance characteristics.
 
 **CPU Profile**
 
-- `/profile` endpoint to record a CPU profile for a given duration using `Profile.@profile`.
-    - Default query params: `/profile?n=1e8&delay=0.01&duration=10&pprof=true`
-- `/profile_start` to start the CPU profiler (without specifying a duration to run for).
-    - Default query params: `/profile_start?n=1e8&delay=0.01`
-- `/profile_stop` to stop the CPU profiler and return the profile.
-    - Default query params: `/profile_stop?pprof=true`
+- `/cpu_profile` endpoint to record a CPU profile for a given duration using `Profile.@profile`.
+    - Default query params: `/cpu_profile?n=1e8&delay=0.01&duration=10&pprof=true`
+- `/cpu_profile_start` to start the CPU profiler (without specifying a duration to run for).
+    - Default query params: `/cpu_profile_start?n=1e8&delay=0.01`
+- `/cpu_profile_stop` to stop the CPU profiler and return the profile.
+    - Default query params: `/cpu_profile_stop?pprof=true`
 
 **Allocation Profile**
 
@@ -51,7 +51,7 @@ julia> for _ in 1:100 peakflops() end  # run stuff to profile (locks up the REPL
 
 Collect a CPU profile:
 ```bash
-$ curl '127.0.0.1:16825/profile?delay=0.01&duration=3' --output prof1.pb.gz
+$ curl '127.0.0.1:16825/cpu_profile?delay=0.01&duration=3' --output prof1.pb.gz
 ```
 
 And view it in PProf:

--- a/src/ProfileEndpoints.jl
+++ b/src/ProfileEndpoints.jl
@@ -10,7 +10,7 @@ using Serialization: serialize
 #----------------------------------------------------------
 #  Description
 #
-# It would be nice if visiting the `/profile` page from a web browser gives you a form where you can:
+# It would be nice if visiting the `/cpu_profile` page from a web browser gives you a form where you can:
 # - configure the Profiling parameters:
 #    - Set julia Profile configuration, either by:
 #       - Manually setting `n` and `delay`, for `Profile.init(n, delay)`, or
@@ -452,9 +452,9 @@ end
 
 function register_endpoints(router; stage_path = nothing)
     @info "Registering profiling endpoints"
-    HTTP.register!(router, "/profile", cpu_profile_endpoint)
-    HTTP.register!(router, "/profile_start", cpu_profile_start_endpoint)
-    HTTP.register!(router, "/profile_stop", cpu_profile_stop_endpoint)
+    HTTP.register!(router, "/cpu_profile", cpu_profile_endpoint)
+    HTTP.register!(router, "/cpu_profile_start", cpu_profile_start_endpoint)
+    HTTP.register!(router, "/cpu_profile_stop", cpu_profile_stop_endpoint)
     HTTP.register!(router, "/heap_snapshot", heap_snapshot_endpoint)
     HTTP.register!(router, "/allocs_profile", allocations_profile_endpoint)
     HTTP.register!(router, "/allocs_profile_start", allocations_start_endpoint)
@@ -473,7 +473,7 @@ function serve_profiling_server(;addr="127.0.0.1", port=16825, verbose=false, st
     return HTTP.serve!(router, addr, port; verbose=verbose, kw...)
 end
 
-# Precompile the endpoints as much as possible, so that your /profile attempt doesn't end
+# Precompile the endpoints as much as possible, so that your /cpu_profile attempt doesn't end
 # up profiling compilation!
 @static if VERSION < v"1.9" # Before Julia 1.9, precompilation didn't stick if not in __init__
     function __init__()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ const url = "http://127.0.0.1:$port"
         @testset "profile endpoint" begin
             done[] = false
             t = workload()
-            req = HTTP.get("$url/profile?duration=3&pprof=false")
+            req = HTTP.get("$url/cpu_profile?duration=3&pprof=false")
             @test req.status == 200
             @test length(req.body) > 0
 
@@ -48,13 +48,13 @@ const url = "http://127.0.0.1:$port"
         @testset "profile_start/stop endpoints" begin
             done[] = false
             t = workload()
-            req = HTTP.get("$url/profile_start")
+            req = HTTP.get("$url/cpu_profile_start")
             @test req.status == 200
             @test String(req.body) == "CPU profiling started."
 
             sleep(3)  # Allow workload to run a while before we stop profiling.
 
-            req = HTTP.get("$url/profile_stop?pprof=false")
+            req = HTTP.get("$url/cpu_profile_stop?pprof=false")
             @test req.status == 200
             data, lidict = deserialize(IOBuffer(req.body))
             # Test that the profile seems like valid profile data
@@ -68,7 +68,7 @@ const url = "http://127.0.0.1:$port"
             # We retrive data via PProf directly if `pprof=true`; make sure that path's tested.
             # This second call to `profile_stop` should still return the profile, even though
             # the profiler is already stopped, as it's `profile_start` that calls `clear()`.
-            req = HTTP.get("$url/profile_stop?pprof=true")
+            req = HTTP.get("$url/cpu_profile_stop?pprof=true")
             @test req.status == 200
             # Test that there's something here
             # TODO: actually parse the profile
@@ -294,7 +294,7 @@ const url = "http://127.0.0.1:$port"
     end
 
     @testset "error handling" begin
-        let res = HTTP.get("$url/profile", status_exception=false)
+        let res = HTTP.get("$url/cpu_profile", status_exception=false)
             @test 400 <= res.status < 500
             @test res.status != 404
             # Make sure we describe how to use the endpoint


### PR DESCRIPTION
Likely a breaking change, but I believe we need this now that we have the wall-time profiler in order to make the distinction between CPU/Wall-time profiles clear.