### PR TITLE
Add wall-time profiles to ProfileEndpoints.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,9 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.6"  # LTS
+          - "1.6"  # min-supported version
           - "1"    # Latest
-          - "~1.9.0-0"  # To test heap snapshot; remove when v1.9 is latest Julia release.
           - "nightly"
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProfileEndpoints"
 uuid = "873a18e9-432f-47dd-82a7-1a805cf6f852"
 authors = ["Nathan Daly <nhdaly@gmail.com>", "Dana Wilson <odioustoad@gmail.com>"]
-version = "2.5.0"
+version = "2.6.0"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -3,8 +3,16 @@ precompile(serve_profiling_server, ()) || error("precompilation of package funct
 precompile(cpu_profile_endpoint, (HTTP.Request,)) || error("precompilation of package functions is not supposed to fail")
 precompile(cpu_profile_start_endpoint, (HTTP.Request,)) || error("precompilation of package functions is not supposed to fail")
 precompile(cpu_profile_stop_endpoint, (HTTP.Request,)) || error("precompilation of package functions is not supposed to fail")
-precompile(_do_cpu_profile, (Int,Float64,Float64,Bool)) || error("precompilation of package functions is not supposed to fail")
-precompile(_start_cpu_profile, (Int,Float64,)) || error("precompilation of package functions is not supposed to fail")
+precompile(wall_profile_endpoint, (HTTP.Request,)) || error("precompilation of package functions is not supposed to fail")
+precompile(wall_profile_start_endpoint, (HTTP.Request,)) || error("precompilation of package functions is not supposed to fail")
+precompile(wall_profile_stop_endpoint, (HTTP.Request,)) || error("precompilation of package functions is not supposed to fail")
+
+precompile(debug_profile_endpoint_with_stage_path, (String,)) || error("precompilation of package functions is not supposed to fail")
+precompile(debug_profile_endpoint_with_stage_path, (Nothing,)) || error("precompilation of package functions is not supposed to fail")
+debug_profile_endpoint_str = debug_profile_endpoint_with_stage_path("stage")
+debug_profile_endpoint_nothing = debug_profile_endpoint_with_stage_path("nothing")
+precompile(debug_profile_endpoint_str, (HTTP.Request,)) || error("precompilation of package functions is not supposed to fail")
+precompile(debug_profile_endpoint_nothing, (HTTP.Request,)) || error("precompilation of package functions is not supposed to fail")
 
 precompile(heap_snapshot_endpoint, (HTTP.Request,)) || error("precompilation of package functions is not supposed to fail")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,7 +171,7 @@ const url = "http://127.0.0.1:$port"
             payload = JSON3.write(Dict("profile_type" => "cpu_profile_start"))
             req = HTTP.post("$url/debug_engine", headers, payload)
             @test req.status == 200
-            @test String(req.body) == "CPU_PROFILING profiling started."
+            @test String(req.body) == "CPU_PROFILE profiling started."
 
             sleep(3)  # Allow workload to run a while before we stop profiling.
 
@@ -219,7 +219,7 @@ const url = "http://127.0.0.1:$port"
             payload = JSON3.write(Dict("profile_type" => "wall_profile_start"))
             req = HTTP.post("$url/debug_engine", headers, payload)
             @test req.status == 200
-            @test String(req.body) == "WALL_PROFILING profiling started."
+            @test String(req.body) == "WALL_PROFILE profiling started."
 
             sleep(3)  # Allow workload to run a while before we stop profiling.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,13 +28,11 @@ end
         done = Threads.Atomic{Bool}(false)
         # Schedule some work that's known to be expensive, to profile it
         workload() = @async begin
-            out = 0
             for _ in 1:1000
                 if done[] return end
-                out += sum(Int[1 for _ in 1:Int(1e9)])
+                InteractiveUtils.peakflops()
                 yield()  # yield to allow the tests to run
             end
-            return out
         end
 
         @testset "profile endpoint" begin
@@ -151,14 +149,12 @@ end
         done = Threads.Atomic{Bool}(false)
         # Schedule some work that's known to be expensive, to profile it
         workload() = @async begin
-            out = 0
-            for _ in 1:10000
+            for _ in 1:1000
                 if done[] return end
-                out += sum(Int[1 for _ in 1:Int(1e5)])
+                InteractiveUtils.peakflops()
                 sleep(0.1)
                 yield()  # yield to allow the tests to run
             end
-            return out
         end
 
         @testset "debug endpoint cpu profile" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -247,7 +247,6 @@ const url = "http://127.0.0.1:$port"
             @test isfile(fname)
         end
 
-
         @testset "Debug endpoint heap snapshot" begin
             @static if isdefined(Profile, :take_heap_snapshot)
                 headers = ["Content-Type" => "application/json"]
@@ -257,6 +256,10 @@ const url = "http://127.0.0.1:$port"
                 fname = read(IOBuffer(req.body), String)
                 @info "filename: $fname"
                 @test isfile(fname)
+                @static if isdefined(Profile, :HeapSnapshot) && isdefined(Profile.HeapSnapshot, :assemble_snapshot) && Sys.isunix()
+                    # test whether the returned file has a tar extension
+                    @test occursin(".tar", fname)
+                end
             end
         end
 
@@ -267,10 +270,6 @@ const url = "http://127.0.0.1:$port"
                 req = HTTP.post("$url/debug_engine", headers, payload)
                 @test req.status == 200
                 fname = read(IOBuffer(req.body), String)
-                @static if isdefined(Profile, :HeapSnapshot) && isdefined(Profile.HeapSnapshot, :assemble_snapshot) && Sys.isunix()
-                    # test whether the returned file has a tar extension
-                    @test occursin(".tar", fname)
-                end
                 @info "filename: $fname"
                 @test isfile(fname)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,10 +10,18 @@ import JSON3
 import Profile
 import PProf
 
-const port = 13423
 const stage_path = tempdir()
-const server = ProfileEndpoints.serve_profiling_server(;port=port, stage_path=stage_path)
-const url = "http://127.0.0.1:$port"
+port = 13423
+# Try a few ports to allow multiple test jobs in parallel on the same machine.
+for _ in 1:5
+    try
+        global server = ProfileEndpoints.serve_profiling_server(;port=port, stage_path=stage_path)
+        global url = "http://127.0.0.1:$port"
+        break
+    catch
+        global port += 1
+    end
+end
 
 @testset "ProfileEndpoints.jl" begin
     @testset "CPU profiling" begin
@@ -78,63 +86,65 @@ const url = "http://127.0.0.1:$port"
         end
     end
 
-    @testset "Wall profiling" begin
-        done = Threads.Atomic{Bool}(false)
-        # Schedule some work that's known to be expensive, to profile it
-        workload() = @async begin
-            for _ in 1:100
-                if done[] return end
-                sleep(1)
-                yield()  # yield to allow the tests to run
+    @static if isdefined(Profile, Symbol("@profile_walltime"))
+        @testset "Wall profiling" begin
+            done = Threads.Atomic{Bool}(false)
+            # Schedule some work that's known to be expensive, to profile it
+            workload() = @async begin
+                for _ in 1:100
+                    if done[] return end
+                    sleep(1)
+                    yield()  # yield to allow the tests to run
+                end
             end
-        end
 
-        @testset "profile endpoint" begin
-            done[] = false
-            t = workload()
-            req = HTTP.get("$url/profile_wall?duration=3&pprof=false")
-            @test req.status == 200
-            @test length(req.body) > 0
+            @testset "profile endpoint" begin
+                done[] = false
+                t = workload()
+                req = HTTP.get("$url/profile_wall?duration=3&pprof=false")
+                @test req.status == 200
+                @test length(req.body) > 0
 
-            data, lidict = deserialize(IOBuffer(req.body))
-            # Test that the profile seems like valid profile data
-            @test data isa Vector{UInt64}
-            @test lidict isa Dict{UInt64, Vector{Base.StackTraces.StackFrame}}
+                data, lidict = deserialize(IOBuffer(req.body))
+                # Test that the profile seems like valid profile data
+                @test data isa Vector{UInt64}
+                @test lidict isa Dict{UInt64, Vector{Base.StackTraces.StackFrame}}
 
-            @info "Finished `profile` tests, waiting for peakflops workload to finish."
-            done[] = true
-            wait(t)  # handle errors
-        end
+                @info "Finished `profile` tests, waiting for peakflops workload to finish."
+                done[] = true
+                wait(t)  # handle errors
+            end
 
-        @testset "profile_start/stop endpoints" begin
-            done[] = false
-            t = workload()
-            req = HTTP.get("$url/profile_wall_start")
-            @test req.status == 200
-            @test String(req.body) == "WALL_PROFILE profiling started."
+            @testset "profile_start/stop endpoints" begin
+                done[] = false
+                t = workload()
+                req = HTTP.get("$url/profile_wall_start")
+                @test req.status == 200
+                @test String(req.body) == "WALL_PROFILE profiling started."
 
-            sleep(3)  # Allow workload to run a while before we stop profiling.
+                sleep(3)  # Allow workload to run a while before we stop profiling.
 
-            req = HTTP.get("$url/profile_stop?pprof=false")
-            @test req.status == 200
-            data, lidict = deserialize(IOBuffer(req.body))
-            # Test that the profile seems like valid profile data
-            @test data isa Vector{UInt64}
-            @test lidict isa Dict{UInt64, Vector{Base.StackTraces.StackFrame}}
+                req = HTTP.get("$url/profile_stop?pprof=false")
+                @test req.status == 200
+                data, lidict = deserialize(IOBuffer(req.body))
+                # Test that the profile seems like valid profile data
+                @test data isa Vector{UInt64}
+                @test lidict isa Dict{UInt64, Vector{Base.StackTraces.StackFrame}}
 
-            @info "Finished `profile_start/stop` tests, waiting for peakflops workload to finish."
-            done[] = true
-            wait(t)  # handle errors
+                @info "Finished `profile_start/stop` tests, waiting for peakflops workload to finish."
+                done[] = true
+                wait(t)  # handle errors
 
-            # We retrive data via PProf directly if `pprof=true`; make sure that path's tested.
-            # This second call to `profile_stop` should still return the profile, even though
-            # the profiler is already stopped, as it's `profile_start` that calls `clear()`.
-            req = HTTP.get("$url/profile_stop?pprof=true")
-            @test req.status == 200
-            # Test that there's something here
-            # TODO: actually parse the profile
-            data = read(IOBuffer(req.body), String)
-            @test length(data) > 100
+                # We retrive data via PProf directly if `pprof=true`; make sure that path's tested.
+                # This second call to `profile_stop` should still return the profile, even though
+                # the profiler is already stopped, as it's `profile_start` that calls `clear()`.
+                req = HTTP.get("$url/profile_stop?pprof=true")
+                @test req.status == 200
+                # Test that there's something here
+                # TODO: actually parse the profile
+                data = read(IOBuffer(req.body), String)
+                @test length(data) > 100
+            end
         end
     end
     @testset "debug endpoints" begin
@@ -199,54 +209,55 @@ const url = "http://127.0.0.1:$port"
             @test isfile(fname)
         end
 
-        @testset "debug endpoint wall profile" begin
-            done[] = false
-            t = workload()
-            headers = ["Content-Type" => "application/json"]
-            payload = JSON3.write(Dict("profile_type" => "wall_profile"))
-            req = HTTP.post("$url/debug_engine", headers, payload)
-            @test req.status == 200
-            fname = read(IOBuffer(req.body), String)
-            @info "filename: $fname"
-            @test isfile(fname)
+        @static if isdefined(Profile, Symbol("@profile_walltime"))
+            @testset "debug endpoint wall profile" begin
+                done[] = false
+                t = workload()
+                headers = ["Content-Type" => "application/json"]
+                payload = JSON3.write(Dict("profile_type" => "wall_profile"))
+                req = HTTP.post("$url/debug_engine", headers, payload)
+                @test req.status == 200
+                fname = read(IOBuffer(req.body), String)
+                @info "filename: $fname"
+                @test isfile(fname)
+            end
+
+            @testset "debug endpoint wall profile start/end" begin
+                done[] = false
+                t = workload()
+                # JSON payload should contain profile_type
+                headers = ["Content-Type" => "application/json"]
+                payload = JSON3.write(Dict("profile_type" => "wall_profile_start"))
+                req = HTTP.post("$url/debug_engine", headers, payload)
+                @test req.status == 200
+                @test String(req.body) == "WALL_PROFILE profiling started."
+
+                sleep(3)  # Allow workload to run a while before we stop profiling.
+
+                payload = JSON3.write(Dict("profile_type" => "wall_profile_stop"))
+                req = HTTP.post("$url/debug_engine", headers, payload)
+                done[] = true
+                @test req.status == 200
+                fname = read(IOBuffer(req.body), String)
+                @info "filename: $fname"
+                @test isfile(fname)
+
+                @info "Finished `debug profile_start/stop` tests, waiting for peakflops workload to finish."
+                wait(t)  # handle errors
+
+                # We retrive data via PProf directly if `pprof=true`; make sure that path's tested.
+                # This second call to `profile_stop` should still return the profile, even though
+                # the profiler is already stopped, as it's `profile_start` that calls `clear()`.
+                payload = JSON3.write(Dict("profile_type" => "cpu_profile_stop", "pprof" => "true"))
+                req = HTTP.post("$url/debug_engine", headers, payload)
+                @test req.status == 200
+                # Test that there's something here
+                # TODO: actually parse the profile
+                fname = read(IOBuffer(req.body), String)
+                @info "filename: $fname"
+                @test isfile(fname)
+            end
         end
-
-        @testset "debug endpoint wall profile start/end" begin
-            done[] = false
-            t = workload()
-            # JSON payload should contain profile_type
-            headers = ["Content-Type" => "application/json"]
-            payload = JSON3.write(Dict("profile_type" => "wall_profile_start"))
-            req = HTTP.post("$url/debug_engine", headers, payload)
-            @test req.status == 200
-            @test String(req.body) == "WALL_PROFILE profiling started."
-
-            sleep(3)  # Allow workload to run a while before we stop profiling.
-
-            payload = JSON3.write(Dict("profile_type" => "wall_profile_stop"))
-            req = HTTP.post("$url/debug_engine", headers, payload)
-            done[] = true
-            @test req.status == 200
-            fname = read(IOBuffer(req.body), String)
-            @info "filename: $fname"
-            @test isfile(fname)
-
-            @info "Finished `debug profile_start/stop` tests, waiting for peakflops workload to finish."
-            wait(t)  # handle errors
-
-            # We retrive data via PProf directly if `pprof=true`; make sure that path's tested.
-            # This second call to `profile_stop` should still return the profile, even though
-            # the profiler is already stopped, as it's `profile_start` that calls `clear()`.
-            payload = JSON3.write(Dict("profile_type" => "cpu_profile_stop", "pprof" => "true"))
-            req = HTTP.post("$url/debug_engine", headers, payload)
-            @test req.status == 200
-            # Test that there's something here
-            # TODO: actually parse the profile
-            fname = read(IOBuffer(req.body), String)
-            @info "filename: $fname"
-            @test isfile(fname)
-        end
-
         @testset "Debug endpoint heap snapshot" begin
             @static if isdefined(Profile, :take_heap_snapshot)
                 headers = ["Content-Type" => "application/json"]


### PR DESCRIPTION
- Through the HTTP endpoints:
    - /profile_wall
    - /profile_wall_start
    - /profile_wall_stop
- Through the debug super-endpoint:
    - /debug_engine profile_type="wall_profile"
    - /debug_engine profile_type="wall_profile_start"
    - /debug_engine profile_type="wall_profile_stop"